### PR TITLE
Added Faded Tube preset

### DIFF
--- a/Presets/Display Specific/Faded Tube.ini
+++ b/Presets/Display Specific/Faded Tube.ini
@@ -1,0 +1,9 @@
+#Faded Tube
+#TrashUncle
+
+hfilter=Upscaling - Recommended/GS_Sharpness_015.txt
+vfilter=Scanlines - Adaptive/SLA_Dk_020_Br_060.txt
+sfilter=off
+gamma=Pure_Gamma/gamma_145.txt
+mask=Complex (Multichromatic)/Tinted/CRT Styles/Generic Faded Tube (Yellow).txt
+maskmode=1x


### PR DESCRIPTION
This preset is using a new mask called Generic Faded Tube (Yellow). This mask, combined with gamma settings and scanline combo, are trying to recreate a CRT that has gone a bit past it's typical burn hours.  Picture is a bit darker with some slight color bleed.