### PR TITLE
Update SNES Scanlines Preset to Use Adaptive Scanlines

### DIFF
--- a/Presets/Core Specific/SNES Scanlines.ini
+++ b/Presets/Core Specific/SNES Scanlines.ini
@@ -1,5 +1,5 @@
 hfilter=Upscaling - Recommended/GS_Sharpness_055.txt
-vfilter=Scanlines - Brighter/105pct Brightness/Scan_Br_105_65.txt
+vfilter=Scanlines - Adaptive/SLA_Dk_060_Br_070.txt
 sfilter=same
 gamma=Pure_Gamma/gamma_113.txt
 maskmode=off


### PR DESCRIPTION
The color matching doesn't seem achievable, the adaptive scanlines are inherently brighter I think due to their changes. But I made sure it matches the similar thickness of the previous scanlines used, and it has a medium taper that isn't too strong.

Before
![Screenshot 2022-04-04 22-05-01](https://user-images.githubusercontent.com/16388068/161676760-a856b574-2b8d-4520-961c-9f440a95f258.png)

After
![Screenshot 2022-04-04 22-04-00](https://user-images.githubusercontent.com/16388068/161676698-45a9b0de-a7cc-428f-af3a-b27c5e2cabb2.png)