### PR TITLE
Minor updates to a few General Hardware presets

### DIFF
--- a/Presets/General Hardware/Arcade - Vertical.ini
+++ b/Presets/General Hardware/Arcade - Vertical.ini
@@ -5,5 +5,5 @@ hfilter=Scanlines - Adaptive/SLA_Dk_070_Br_080.txt
 vfilter=Upscaling - Lanczos Bicubic etc/lanczos2_12.txt
 sfilter=same
 gamma=Poly_Gamma/Poly 2.3.txt
-mask=Sony PVM (Generic) (~1980).txt
+mask=Simple (Monochrome)/Sony PVM (Generic) (~1980).txt
 maskmode=1x rotated

--- a/Presets/General Hardware/Arcade.ini
+++ b/Presets/General Hardware/Arcade.ini
@@ -5,5 +5,5 @@ hfilter=Upscaling - Lanczos Bicubic etc/lanczos2_12.txt
 vfilter=Scanlines - Adaptive/SLA_Dk_070_Br_080.txt
 sfilter=same
 gamma=Poly_Gamma/Poly 2.3.txt
-mask=Sony PVM (Generic) (~1980).txt
+mask=Simple (Monochrome)/Sony PVM (Generic) (~1980).txt
 maskmode=1x

--- a/Presets/General Hardware/Console - 5thGen.ini
+++ b/Presets/General Hardware/Console - 5thGen.ini
@@ -5,5 +5,5 @@ hfilter=Upscaling - Recommended/GS_Sharpness_055.txt
 vfilter=Scanlines - Adaptive/SLA_Dk_070_Br_080.txt
 sfilter=same
 gamma=Poly_Gamma/Poly 2.4.txt
-mask=Simple (Monochrome)/RetroTink/AG-2.txt
+mask=Simple (Monochrome)/RetroTink/AG-1.txt
 maskmode=1x

--- a/Presets/General Hardware/Console - 5thGen.ini
+++ b/Presets/General Hardware/Console - 5thGen.ini
@@ -5,5 +5,5 @@ hfilter=Upscaling - Recommended/GS_Sharpness_055.txt
 vfilter=Scanlines - Adaptive/SLA_Dk_070_Br_080.txt
 sfilter=same
 gamma=Poly_Gamma/Poly 2.4.txt
-mask=Simple (Monochrome)/RetroTink/Consumer-2.txt
+mask=Simple (Monochrome)/RetroTink/AG-2.txt
 maskmode=1x


### PR DESCRIPTION
Updated the "Console - 5th Gen" preset to use a shadowmask that works better for all vscale options and updated "Arcade" / "Arcade - Vertical" presets to follow submission guidelines by using a shadowmask within a subdirectory.