### PR TITLE
Adding additional arcade filters

### DIFF
--- a/Presets/General Hardware/Arcade 80s - Vertical.ini
+++ b/Presets/General Hardware/Arcade 80s - Vertical.ini
@@ -1,9 +1,9 @@
 #Settings to mimic a vertically oriented arcade game monitor from the late 80s
-By @RGarciaLago
+#By @RGarciaLago
 
-hfilter=Scanlines - Adaptive/SLA_Dk_070_Br_080.txt
-vfilter=Upscaling - Lanczos Bicubic etc/lanczos2_12.txt
+hfilter=Scanlines - Adaptive/SLA_Dk_060_Br_070.txt
+vfilter=Upscaling - Recommended/GS_Sharpness_040.txt
 sfilter=same
-gamma=Poly_Gamma/Poly 2.3.txt
+gamma=Pure_Gamma/gamma_150.txt
 mask=Simple (Monochrome)/Sony PVM (Generic) (~1980).txt
 maskmode=1x rotated

--- a/Presets/General Hardware/Arcade 80s.ini
+++ b/Presets/General Hardware/Arcade 80s.ini
@@ -1,0 +1,9 @@
+#Presets to mimic an arcade game monitor from the early 80s
+#By @RGarciaLago
+
+hfilter=Upscaling - Recommended/GS_Sharpness_040.txt
+vfilter=Scanlines - Adaptive/SLA_Dk_060_Br_070.txt
+sfilter=same
+gamma=Pure_Gamma/gamma_150.txt
+mask=Simple (Monochrome)/Sony PVM (Generic) (~1980).txt
+maskmode=1x

--- a/Presets/General Hardware/Arcade 90s - Vertical.ini
+++ b/Presets/General Hardware/Arcade 90s - Vertical.ini
@@ -1,0 +1,9 @@
+#Settings to mimic a vertically oriented arcade game monitor from the 90s and later
+#By @RGarciaLago
+
+hfilter=Scanlines - Adaptive/SLA_Dk_080_Br_080.txt
+vfilter=Upscaling - Recommended/GS_Sharpness_080.txt
+sfilter=same
+gamma=Contrast_Boost/Contrast_Boost_2.txt
+mask=Simple (Monochrome)/Aperture Grille (No Scanlines) (1968).txt
+maskmode=1x rotated

--- a/Presets/General Hardware/Arcade 90s.ini
+++ b/Presets/General Hardware/Arcade 90s.ini
@@ -1,0 +1,9 @@
+#Settings to mimic an arcade game monitor from the 90s and later
+#By @RGarciaLago
+
+hfilter=Upscaling - Recommended/GS_Sharpness_080.txt
+vfilter=Scanlines - Adaptive/SLA_Dk_080_Br_080.txt
+sfilter=same
+gamma=Contrast_Boost/Contrast_Boost_2.txt
+mask=Simple (Monochrome)/Aperture Grille (No Scanlines) (1968).txt
+maskmode=1x

--- a/Presets/General Hardware/Arcade.ini
+++ b/Presets/General Hardware/Arcade.ini
@@ -1,5 +1,5 @@
-#Standard Arcade games
-#By @RGarciaLago
+#Settings to mimic an arcade game monitor from the late 80s
+By @RGarciaLago
 
 hfilter=Upscaling - Lanczos Bicubic etc/lanczos2_12.txt
 vfilter=Scanlines - Adaptive/SLA_Dk_070_Br_080.txt


### PR DESCRIPTION
These 80s and 90s arcade filters are meant to complement the existing Arcade one. They represent what you'd might see playing a game with monitor display tech from the early 80s and the 90s. Updated the existing Arcade.ini (and vertical) so its description is similar to the others and identifies it as a late 80s preset.