### PR TITLE
N64 presets

### DIFF
--- a/Presets/Core Specific/N64 Reduced Blur.ini
+++ b/Presets/Core Specific/N64 Reduced Blur.ini
@@ -1,0 +1,7 @@
+#N64 (for reducing blur with VI bilinear ON)
+
+hfilter=N64 Reduced Blur.txt
+vfilter=No Interpolation.txt
+sfilter=same
+gamma=off
+maskmode=off

--- a/Presets/Core Specific/N64 Tiny Blur.ini
+++ b/Presets/Core Specific/N64 Tiny Blur.ini
@@ -1,0 +1,7 @@
+#N64 (for adding a tiny blur with VI bilinear OFF)
+
+hfilter=N64 Tiny Blur.txt
+vfilter=No Interpolation.txt
+sfilter=same
+gamma=off
+maskmode=off


### PR DESCRIPTION
N64 Reduced Blur: Reduces blur, meant for using with VI bilinear ON
N64 Tiny Blur: Adds a tiny blur, meant for using with VI bilinear OFF